### PR TITLE
Fix for automatic cucumber tests in Play 1.2.5

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -79,7 +79,7 @@ def cukes(app, args):
         line = soutint.readline().strip()        
         if line:
             print line
-            if line.find('Listening for HTTP') > -1:
+            if line.find('@cukes') > -1:
                 #soutint.close()
                 break
   


### PR DESCRIPTION
The Play framework has changed the text that is written when it is ready.
Because of this it is not possible to run tests from command line. This fix
checks for a text "@cukes" that are written by the plugin itself and should
work for all versions of Play that the plugin is ment for.
